### PR TITLE
Fourth / Added TitleBracketsValidator

### DIFF
--- a/app/validators/title_brackets_validator.rb
+++ b/app/validators/title_brackets_validator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class TitleBracketsValidator < ActiveModel::Validator
+  BRACKETS = { '{' => '}', '[' => ']', '(' => ')' }.freeze
+
+  def validate(record)
+    return record.errors[:title] << 'value should be String' unless record.title.is_a? String
+
+    unless opened_brackets?(record.title)
+      record.errors[:title] << 'There are opened or empty brackets'
+    end
+  end
+
+  private
+
+  def opened_brackets?(title)
+    title.each_char.with_index.with_object([]) do |char_with_index, opened_brackets|
+      char, index = *char_with_index
+      opened_brackets << char && next if BRACKETS.key?(char)
+
+      BRACKETS.key(char).yield_self do |opened_bracket|
+        if opened_bracket && (empty_brackets?(title, index) || opened_bracket != opened_brackets.pop)
+          return false
+        end
+      end
+    end.empty?
+  end
+
+  def empty_brackets?(title, index)
+    BRACKETS.key?(title[index - 1])
+  end
+end

--- a/spec/validators/title_brackets_validator_spec.rb
+++ b/spec/validators/title_brackets_validator_spec.rb
@@ -1,87 +1,92 @@
-# require "rails_helper"
+require "rails_helper"
 
-# describe TitleBracketsValidator do
-#   subject { Validatable.new(title: title) }
+describe TitleBracketsValidator do
+  subject { Validatable.new(title: title) }
 
-#   shared_examples "has valid title" do
-#     it "should be valid" do
-#       expect(subject).to be_valid
-#     end
-#   end
+  shared_examples "has valid title" do
+    it "should be valid" do
+      expect(subject).to be_valid
+    end
+  end
 
-#   shared_examples "has invalid title" do
-#     it "should not be valid" do
-#       expect(subject).not_to be_valid
-#     end
-#   end
+  shared_examples "has invalid title" do
+    it "should not be valid" do
+      expect(subject).not_to be_valid
+    end
+  end
 
-#   context "with curly brackets" do
-#     let(:title) { "The Fellowship of the Ring {Peter Jackson}" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with curly brackets" do
+    let(:title) { "The Fellowship of the Ring {Peter Jackson}" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with square brackets" do
-#     let(:title) { "The Fellowship of the Ring [Lord of The Rings]" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with square brackets" do
+    let(:title) { "The Fellowship of the Ring [Lord of The Rings]" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with not closed brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not closed brackets" do
+    let(:title) { "The Fellowship of the Ring (2001" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with not opened brackets" do
-#     let(:title) { "The Fellowship of the Ring 2001)" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not opened brackets" do
+    let(:title) { "The Fellowship of the Ring 2001)" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with not too much closing brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001) - 2003)" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not too much closing brackets" do
+    let(:title) { "The Fellowship of the Ring (2001) - 2003)" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with not too much opening brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001 - (2003)" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not too much opening brackets" do
+    let(:title) { "The Fellowship of the Ring (2001 - (2003)" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with empty brackets" do
-#     let(:title) { "The Fellowship of the Ring ()" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with empty brackets" do
+    let(:title) { "The Fellowship of the Ring ()" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with brackets in wrong order" do
-#     let(:title) { "The Fellowship of the )Ring(" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with brackets in wrong order" do
+    let(:title) { "The Fellowship of the )Ring(" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with matching brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001)" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with matching brackets" do
+    let(:title) { "The Fellowship of the Ring (2001)" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with multiple matching brackets" do
-#     let(:title) { "The Fellowship of the Ring [Lord of The Rings] (2001) {Peter Jackson}" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with multiple matching brackets" do
+    let(:title) { "The Fellowship of the Ring [Lord of The Rings] (2001) {Peter Jackson}" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with nested matching brackets" do
-#     let(:title) { "The Fellowship of the Ring [Lord of The Rings {Peter Jackson}] (2012)" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with nested matching brackets" do
+    let(:title) { "The Fellowship of the Ring [Lord of The Rings {Peter Jackson}] (2012)" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with no brackets" do
-#     let(:title) { "Lord of The Rings" }
-#     it_behaves_like "has valid title"
-#   end
-# end
+  context "with no brackets" do
+    let(:title) { "Lord of The Rings" }
+    it_behaves_like "has valid title"
+  end
 
-# class Validatable
-#   include ActiveModel::Validations
-#   validates_with TitleBracketsValidator
-#   attr_accessor :title
+  context "with no String title" do
+    let(:title) { 123 }
+    it_behaves_like "has invalid title"
+  end
+end
 
-#   def initialize(title:)
-#     @title = title
-#   end
-# end
+class Validatable
+  include ActiveModel::Validations
+  validates_with TitleBracketsValidator
+  attr_accessor :title
+
+  def initialize(title:)
+    @title = title
+  end
+end


### PR DESCRIPTION
### Where

https://github.com/DimaAlex/pairguru#task-4---brackets-validation

### What

We need to add add title validator because our moderators are adding parentheses and brackets to the titles.

### How

Added custom `TitleBracketsValidator`

Note: TBH I prefer to inherit from `ActiveModel::EachValidator` because in this way we can add validations to models like `validates :title, open_brackets: true` and it looks more beautiful for me. But I did not want to change specs a lot in order not to confuse reviewers.