### PR TITLE
Second / Build movies api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "5.2"
 
+gem "active_model_serializers", "~> 0.10.0"
 gem "annotate"
 gem "bootstrap-sass"
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.0)
       activesupport (= 5.2.0)
       globalid (>= 0.3.6)
@@ -78,6 +83,8 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.0)
+    case_transform (0.2)
+      activesupport
     choice (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -131,6 +138,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
+    jsonapi-renderer (0.2.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.6.0)
@@ -290,6 +298,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   annotate
   better_errors
   binding_of_caller
@@ -319,4 +328,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Api::V1::BaseController < ActionController::API
+  include ::Api::Response
+  include ::Api::ExceptionHandler
+
+  before_action :authenticate!
+
+  respond_to :json
+
+  private
+
+  def authenticate!
+    head :unauthorized unless authorized?
+  end
+
+  def authorized?
+    ActiveSupport::SecurityUtils.secure_compare(api_key, Rails.configuration.api_key)
+  end
+
+  def api_key
+    (params[:apikey] || request.headers[:apikey]).to_s
+  end
+end

--- a/app/controllers/api/v1/extended_movies_controller.rb
+++ b/app/controllers/api/v1/extended_movies_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ExtendedMoviesController < BaseController
+      def index
+        render json: Movie.includes(:genre).all,
+               each_serializer: ::Api::V1::ExtendedMovieSerializer,
+               status: :ok
+      end
+
+      def show
+        render json: movie, serializer: ::Api::V1::ExtendedMovieSerializer, status: :ok
+      end
+
+      private
+
+      def movie
+        @movie ||= Movie.includes(:genre).find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class MoviesController < BaseController
+      def index
+        json_response Movie.all
+      end
+
+      def show
+        json_response movie
+      end
+
+      private
+
+      def movie
+        @movie ||= Movie.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/api/exception_handler.rb
+++ b/app/controllers/concerns/api/exception_handler.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api::ExceptionHandler
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      json_response({ message: e.message }, :not_found)
+    end
+
+    rescue_from ActiveRecord::RecordInvalid do |e|
+      json_response({ message: e.message }, :unprocessable_entity)
+    end
+
+    rescue_from StandardError do |e|
+      Rails.logger.error(e)
+      json_response({ message: 'Unexpected error happened' }, :internal_server_error)
+    end
+  end
+end

--- a/app/controllers/concerns/api/response.rb
+++ b/app/controllers/concerns/api/response.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Api::Response
+  def json_response(object, status = :ok)
+    render json: object, status: status
+  end
+end

--- a/app/serializers/api/v1/extended_movie_serializer.rb
+++ b/app/serializers/api/v1/extended_movie_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ExtendedMovieSerializer < MovieSerializer
+      belongs_to :genre
+    end
+  end
+end

--- a/app/serializers/api/v1/genre_serializer.rb
+++ b/app/serializers/api/v1/genre_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Api::V1::GenreSerializer < ActiveModel::Serializer
+  attributes :id, :name, :movie_count
+
+  def movie_count
+    object.movies.count
+  end
+end

--- a/app/serializers/api/v1/movie_serializer.rb
+++ b/app/serializers/api/v1/movie_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Api::V1::MovieSerializer < ActiveModel::Serializer
+  attributes :id, :title
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,4 +62,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  Rails.configuration.api_key = 'api_key_development'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  Rails.configuration.api_key = 'api_key_test'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :movies, only: %i[index show]
+      resources :extended_movies, only: %i[index show]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,10 @@ Rails.application.routes.draw do
       get :export
     end
   end
+
+  namespace :api do
+    namespace :v1 do
+      resources :movies, only: %i[index show]
+    end
+  end
 end

--- a/spec/controllers/api/v1/extended_movies_controller_spec.rb
+++ b/spec/controllers/api/v1/extended_movies_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::ExtendedMoviesController, type: :controller do
+  let!(:movie) { create(:movie) }
+  let!(:genre) { movie.genre }
+  let(:apikey) { 'api_key_test' }
+  let(:json_response) { JSON.parse(response.body, symbolize_names: true) }
+  let(:expected_response_body) do
+    [{
+      id: movie.id,
+      title: movie.title,
+      genre: {
+        id: genre.id,
+        name: genre.name,
+        movie_count: genre.movies.count
+      }
+    }]
+  end
+
+  it_behaves_like 'authenticable', :index
+
+  describe 'GET /api/v1/extended_movies' do
+    context 'when request is successful' do
+      before { request.headers['apikey'] = apikey }
+
+      it 'returns correct response' do
+        get :index, format: :json
+        expect(json_response).to eq(expected_response_body)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/extended_movies/:id' do
+    before { request.headers['apikey'] = apikey }
+
+    it 'returns correct response' do
+      get :show, params: { id: movie.id, format: :json }
+      expect(json_response).to eq(expected_response_body.first)
+    end
+  end
+end

--- a/spec/controllers/api/v1/extended_movies_controller_spec.rb
+++ b/spec/controllers/api/v1/extended_movies_controller_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe Api::V1::ExtendedMoviesController, type: :controller do
   let!(:movie) { create(:movie) }
   let!(:genre) { movie.genre }
-  let(:apikey) { 'api_key_test' }
   let(:json_response) { JSON.parse(response.body, symbolize_names: true) }
   let(:expected_response_body) do
     [{
@@ -19,11 +18,11 @@ RSpec.describe Api::V1::ExtendedMoviesController, type: :controller do
     }]
   end
 
-  it_behaves_like 'authenticable', :index
-
   describe 'GET /api/v1/extended_movies' do
+    it_behaves_like 'authenticable', :index
+
     context 'when request is successful' do
-      before { request.headers['apikey'] = apikey }
+      include_context 'with apikey'
 
       it 'returns correct response' do
         get :index, format: :json
@@ -33,7 +32,7 @@ RSpec.describe Api::V1::ExtendedMoviesController, type: :controller do
   end
 
   describe 'GET /api/v1/extended_movies/:id' do
-    before { request.headers['apikey'] = apikey }
+    include_context 'with apikey'
 
     it 'returns correct response' do
       get :show, params: { id: movie.id, format: :json }

--- a/spec/controllers/api/v1/movies_controller_spec.rb
+++ b/spec/controllers/api/v1/movies_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::MoviesController, type: :controller do
+  let!(:movie) { create(:movie) }
+  let(:apikey) { 'api_key_test' }
+  let(:json_response) { JSON.parse(response.body, symbolize_names: true) }
+  let(:expected_response_body) do
+    [{
+      id: movie.id,
+      title: movie.title
+    }]
+  end
+
+  it_behaves_like 'authenticable', :index
+
+  describe 'GET /api/v1/movies' do
+    context 'when request is successful' do
+      let(:expected_response_body) do
+        [{
+          id: movie.id,
+          title: movie.title
+        }]
+      end
+
+      before { request.headers['apikey'] = apikey }
+
+      it 'returns correct response' do
+        get :index, format: :json
+        expect(json_response).to eq(expected_response_body)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/movies/:id' do
+    before { request.headers['apikey'] = apikey }
+
+    it 'returns correct response' do
+      get :show, params: { id: movie.id, format: :json }
+      expect(json_response).to eq(expected_response_body.first)
+    end
+  end
+end

--- a/spec/controllers/api/v1/movies_controller_spec.rb
+++ b/spec/controllers/api/v1/movies_controller_spec.rb
@@ -13,18 +13,11 @@ RSpec.describe Api::V1::MoviesController, type: :controller do
     }]
   end
 
-  it_behaves_like 'authenticable', :index
-
   describe 'GET /api/v1/movies' do
-    context 'when request is successful' do
-      let(:expected_response_body) do
-        [{
-          id: movie.id,
-          title: movie.title
-        }]
-      end
+    it_behaves_like 'authenticable', :index
 
-      before { request.headers['apikey'] = apikey }
+    context 'when request is successful' do
+      include_context 'with apikey'
 
       it 'returns correct response' do
         get :index, format: :json
@@ -34,7 +27,7 @@ RSpec.describe Api::V1::MoviesController, type: :controller do
   end
 
   describe 'GET /api/v1/movies/:id' do
-    before { request.headers['apikey'] = apikey }
+    include_context 'with apikey'
 
     it 'returns correct response' do
       get :show, params: { id: movie.id, format: :json }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,8 +22,8 @@ SimpleCov.start "rails"
 # of increasing the boot-up time by auto-requiring all files in the support
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
-#
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -39,6 +39,7 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.include Devise::Test::ControllerHelpers, type: :controller
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/support/shared_contexts/api_key_contexts.rb
+++ b/spec/support/shared_contexts/api_key_contexts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'with apikey' do
+  let(:apikey) { 'api_key_test' }
+
+  before { request.headers['apikey'] = apikey }
+end

--- a/spec/support/shared_examples/authenticable.rb
+++ b/spec/support/shared_examples/authenticable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'authenticable' do |end_point|
+  it 'rejects request without token' do
+    get end_point, format: :json
+
+    expect(response.code).to eq '401'
+  end
+end


### PR DESCRIPTION
### Where

https://github.com/DimaAlex/pairguru#task-2---build-api

### What

We would like to share our movies via api.
- allow for user to get specific movie by id
- return list of all movies (id and title)
- extend results by adding genre details (genre id, name and number of movies in this genre to be returned along with the movies) - don't break api for existing users or make them to fetch more data

### How

1. Added active_model_serializers to serialize objects
2. Added Api:V1::MoviesController
3. Api::V1::ExtendedMoviesController

Note: I think the API version should only be upgraded when a significant breaking change is made on it - may be a change in the authentication mechanism, moving from JSON to XML, changing the format of the API URLs. Also, when a new version of the API is released, it usually has the intention to deprecate the old version, so when v2 is released, v1 gets deprecated. This means that normally when a new version of the API is created, the whole set of endpoints exposed for v1 also gets migrated to v2, adapted to the changes that made the migration happen. It is very confusing for API consumers to know that for this feature they need to use v1, while for this other feature they must use v2. So in my opinion it's easier just to add new endpoint.